### PR TITLE
feat: Update permissions in settings.json

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -5,7 +5,6 @@
   "permissions": {
     "allow": [
       "Bash",
-      "Bash(*:*)",
       "List(*)",
       "Read(*)",
       "Write(*)",
@@ -16,9 +15,9 @@
       "Fetch(*)",
       "WebSearch",
       "WebFetch",
-      "WebFetch(*)",
       "Bash(mkdir:*)",
-      "mcp__serena"
+      "mcp__serena",
+      "mcp__playwright"
     ],
     "deny": [
       "Bash(git push --no-verify)",


### PR DESCRIPTION
This pull request makes minor updates to the permissions configuration in `settings.json`, primarily by refining allowed permission entries and adding a new permission.

* Permissions refinement:
  * Removed the broad permission entries `"Bash(*:*)"` and `"WebFetch(*)"` from the allow list, tightening the scope of allowed actions. [[1]](diffhunk://#diff-e9e1aabe0aae56cb1eba125e053b355aaf43680cf243ee7b518e1c897e5868c1L8) [[2]](diffhunk://#diff-e9e1aabe0aae56cb1eba125e053b355aaf43680cf243ee7b518e1c897e5868c1L19-R20)

* Permission additions:
  * Added `"mcp__playwright"` to the allow list, enabling access to this capability.

- close #24 